### PR TITLE
feat: create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# Titolo della PR
+<!-- Usa lo schema Conventional Commits: feat:, fix:, docs:, refactor:, ecc. -->
+
+## Scopo / Contesto
+<!-- Spiega brevemente perché questa PR esiste e cosa risolve -->
+
+## Cosa cambia
+<!-- Elenca le modifiche principali -->
+- [ ] Nuova funzionalità
+- [ ] Correzione bug
+- [ ] Aggiornamento documentazione
+
+## Come testare
+<!-- Istruzioni per riprodurre e verificare le modifiche -->
+
+## Checklist
+- [ ] Codice testato in locale (desktop e mobile)
+- [ ] Commit con messaggi chiari e coerenti
+- [ ] Documentazione aggiornata (se serve)
+- [ ] Nessun file superfluo (zip, log, build)
+
+## Issue collegate
+<!-- Closes #numeroIssue -->


### PR DESCRIPTION
Aggiunge file .github/pull_request_template.md

- Scopo: introdurre un template standard per tutte le PR
- Come testare: aprire una nuova PR e verificare che il template venga proposto automaticamente