### PR TITLE
feat: Add custom logo and responsive menu

### DIFF
--- a/themes/news25/css/burger-menu-style.css
+++ b/themes/news25/css/burger-menu-style.css
@@ -1,39 +1,164 @@
 @charset "utf-8";
-/*--------------BURGER-MENU----------------*/
-@media all and (max-width: 1020px) {
-  #menu { width:100%; height:100%; }
 
-  #menu #menu-nav{
-    display:none;                 /* chiuso di default */
-    position:fixed; left:0; top:0; width:100%; height:100vh;
-    background:#000; z-index:10000;
-    padding:90px 30px 30px; overflow-y:auto;
-  }
+/*
+==========================================================================
+    BURGER MENU E NAVIGAZIONE MOBILE
+==========================================================================
+*/
 
-  #menu #menu-nav li{ border-top:1px solid #ddd; cursor: pointer;}
-  #menu #menu-nav li:nth-last-of-type(1){ border-bottom:1px solid #ddd; }
+/* Stili per il burger menu (sotto i 1021px) */
+@media all and (max-width: 1021px) {
+    .site-header .container {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
 
-  #menu a{ color:#fff; padding:14px 16px; text-decoration:none; font-size:17px; display:block; }
-  #menu a.burg-icon{ background:transparent; display:block; position:absolute; right:0; top:0; z-index:10001; color:#fff; }
-  i.fa-bars{ font-size:2em; }
+    .menu-toggle {
+        display: block; /* Mostra il bottone del burger */
+    }
 
-  /* Submenu accordion */
-  #menu #menu-nav .sub-menu{ display:none; padding-left:20px; }
-  #menu #menu-nav ul .sub-menu{ border-top:none; padding-left:20px; }
-  #menu #menu-nav .menu-item-has-children > a{ position:relative; }
-  #menu #menu-nav .menu-item-has-children > a::after{
-    content:'+'; position:absolute; right:15px; top:50%; transform:translateY(-50%); font-size:22px; color:#fff; }
-  #menu #menu-nav li.active > a{ background:#1c1c1c; font-weight:bold; }
-  #menu #menu-nav li.active > a::after{ content:'−'; }
-  #menu #menu-nav li.active > .sub-menu{ display:block; background:#111; }
-  #menu #menu-nav .sub-menu a{ padding-left:30px; font-size:16px; border-color:#444; }
+    .site-navigation {
+        display: none; /* Nasconde il menu di navigazione */
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100vh;
+        background: #000;
+        z-index: 10000;
+        padding: 90px 30px 30px;
+        overflow-y: auto;
+    }
 
-  /* quando aperto */
-  body.nav-open #menu #menu-nav{ display:block; }
+    .site-navigation.toggled-on {
+        display: block; /* Mostra il menu quando aperto */
+    }
 
-  /* nascondi il nav orizzontale quando l’overlay è aperto */
- /* body.nav-open header#header nav#menu .menu-main-container,
-  body.nav-open header#header nav#menu ul#menu-nav.menu{
-    visibility:hidden; pointer-events:none;
-  }*/
+    .site-navigation ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .site-navigation li {
+        border-top: 1px solid #ddd;
+        cursor: pointer;
+    }
+
+    .site-navigation li:last-child {
+        border-bottom: 1px solid #ddd;
+    }
+
+    .site-navigation a {
+        color: #fff;
+        padding: 14px 16px;
+        text-decoration: none;
+        font-size: 17px;
+        display: block;
+    }
+
+    /* Stili per sottomenu */
+    .site-navigation .sub-menu {
+        display: none;
+        padding-left: 20px;
+    }
+
+    .site-navigation .menu-item-has-children > a {
+        position: relative;
+    }
+
+    .site-navigation .menu-item-has-children > a::after {
+        content: '+';
+        position: absolute;
+        right: 15px;
+        top: 50%;
+        transform: translateY(-50%);
+        font-size: 22px;
+        color: #fff;
+    }
+
+    .site-navigation li.active > a {
+        background: #1c1c1c;
+        font-weight: bold;
+    }
+
+    .site-navigation li.active > a::after {
+        content: '−';
+    }
+
+    .site-navigation li.active > .sub-menu {
+        display: block;
+        background: #111;
+    }
+
+    .site-navigation .sub-menu a {
+        padding-left: 30px;
+        font-size: 16px;
+        border-color: #444;
+    }
+}
+
+/*
+==========================================================================
+    NAVIGAZIONE DESKTOP
+==========================================================================
+*/
+
+/* Stili per la navigazione desktop (sopra i 1021px) */
+@media all and (min-width: 1022px) {
+    .menu-toggle {
+        display: none; /* Nasconde il bottone del burger */
+    }
+
+    .site-header .container {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .site-navigation {
+        display: block !important; /* Assicura che la navigazione sia visibile */
+    }
+
+    .site-navigation ul#primary-menu {
+        display: flex;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .site-navigation ul#primary-menu > li {
+        margin-left: 20px;
+    }
+
+    .site-navigation ul#primary-menu > li > a {
+        text-decoration: none;
+        padding: 10px;
+    }
+
+    /* Gestione sottomenu desktop */
+    .site-navigation .sub-menu {
+        display: none;
+        position: absolute;
+        background-color: #fff;
+        box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        z-index: 1000;
+        list-style: none;
+        padding: 0;
+    }
+
+    .site-navigation li:hover > .sub-menu {
+        display: block;
+    }
+
+    .site-navigation .sub-menu li {
+        width: 200px;
+    }
+
+    .site-navigation .sub-menu a {
+        padding: 10px 15px;
+        display: block;
+        color: #333;
+    }
 }

--- a/themes/news25/functions.php
+++ b/themes/news25/functions.php
@@ -82,3 +82,94 @@ function news25_enqueue_assets() {
     }
 }
 add_action('wp_enqueue_scripts', 'news25_enqueue_assets', 20);
+
+// =========================================================================
+// 2. SUPPORTO AL LOGO
+// =========================================================================
+
+/**
+ * Aggiunge il supporto per il logo personalizzato.
+ */
+function news25_logo_setup() {
+    add_theme_support('custom-logo', [
+        'height'      => 100,
+        'width'       => 400,
+        'flex-height' => true,
+        'flex-width'  => true,
+    ]);
+}
+add_action('after_setup_theme', 'news25_logo_setup');
+
+/**
+ * Registra le impostazioni del Customizer per il logo.
+ *
+ * @param WP_Customize_Manager $wp_customize Oggetto Customizer.
+ */
+function news25_customize_register($wp_customize) {
+    // Pannello impostazioni tema
+    $wp_customize->add_panel('news25_theme_panel', [
+        'title'    => __('Impostazioni Tema News25', 'news25'),
+        'priority' => 10,
+    ]);
+
+    // Sezione per il logo
+    $wp_customize->add_section('news25_logo_section', [
+        'title'    => __('Gestione Logo', 'news25'),
+        'panel'    => 'news25_theme_panel',
+        'priority' => 10,
+    ]);
+
+    // Impostazione per il logo retina
+    $wp_customize->add_setting('news25_retina_logo', [
+        'default'           => '',
+        'sanitize_callback' => 'esc_url_raw',
+    ]);
+
+    // Controllo per il logo retina
+    $wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, 'news25_retina_logo', [
+        'label'    => __('Logo Retina (2x)', 'news25'),
+        'section'  => 'news25_logo_section',
+        'settings' => 'news25_retina_logo',
+    ]));
+
+    // Impostazione per il logo mobile
+    $wp_customize->add_setting('news25_mobile_logo', [
+        'default'           => '',
+        'sanitize_callback' => 'esc_url_raw',
+    ]);
+
+    // Controllo per il logo mobile
+    $wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, 'news25_mobile_logo', [
+        'label'    => __('Logo Mobile', 'news25'),
+        'section'  => 'news25_logo_section',
+        'settings' => 'news25_mobile_logo',
+    ]));
+}
+add_action('customize_register', 'news25_customize_register');
+
+/**
+ * Mostra il logo del sito con supporto per retina e mobile.
+ */
+function news25_the_custom_logo() {
+    $custom_logo_id = get_theme_mod('custom_logo');
+    $retina_logo_url = get_theme_mod('news25_retina_logo');
+    $mobile_logo_url = get_theme_mod('news25_mobile_logo');
+    $logo_image_url = wp_get_attachment_image_url($custom_logo_id, 'full');
+
+    $output = '';
+
+    if (wp_is_mobile() && !empty($mobile_logo_url)) {
+        $output = '<a href="' . esc_url(home_url('/')) . '" rel="home">';
+        $output .= '<img src="' . esc_url($mobile_logo_url) . '" alt="' . get_bloginfo('name') . '">';
+        $output .= '</a>';
+    } elseif ($custom_logo_id) {
+        $output = '<a href="' . esc_url(home_url('/')) . '" rel="home">';
+        $srcset = !empty($retina_logo_url) ? ' srcset="' . esc_url($retina_logo_url) . ' 2x"' : '';
+        $output .= '<img src="' . esc_url($logo_image_url) . '" alt="' . get_bloginfo('name') . '"' . $srcset . '>';
+        $output .= '</a>';
+    } else {
+        $output = '<a href="' . esc_url(home_url('/')) . '" rel="home">' . get_bloginfo('name') . '</a>';
+    }
+
+    echo $output;
+}

--- a/themes/news25/template-parts/header-content.php
+++ b/themes/news25/template-parts/header-content.php
@@ -9,7 +9,7 @@
 <header id="masthead" class="site-header">
 	<div class="container">
 		<div class="site-branding">
-			<?php the_custom_logo(); ?>
+			<?php news25_the_custom_logo(); ?>
 		</div><!-- .site-branding -->
 
 		<nav id="site-navigation" class="site-navigation">


### PR DESCRIPTION
- Adds a customizer section to upload a site logo, with separate fields for retina and mobile versions.
- Implements a custom function `news25_the_custom_logo()` to display the appropriate logo based on the device, including `srcset` for retina displays.
- Updates the header template to use the new logo function.
- Refactors the navigation CSS to be fully responsive.
- On desktops (1022px and wider), the menu is displayed horizontally using flexbox.
- On smaller screens (1021px and narrower), a burger menu is displayed. The menu toggle button was already present in the markup.

# Titolo della PR
<!-- Usa lo schema Conventional Commits: feat:, fix:, docs:, refactor:, ecc. -->

## Scopo / Contesto
<!-- Spiega brevemente perché questa PR esiste e cosa risolve -->

## Cosa cambia
<!-- Elenca le modifiche principali -->
- [x] Nuova funzionalità
- [ ] Correzione bug
- [ ] Aggiornamento documentazione

## Come testare
<!-- Istruzioni per riprodurre e verificare le modifiche -->

## Checklist
- [ ] Codice testato in locale (desktop e mobile)
- [ ] Commit con messaggi chiari e coerenti
- [ ] Documentazione aggiornata (se serve)
- [ ] Nessun file superfluo (zip, log, build)

## Issue collegate
<!-- Closes #numeroIssue -->
